### PR TITLE
Fix Stripe webhook database schema mismatch

### DIFF
--- a/backend/src/controllers/stripeController.js
+++ b/backend/src/controllers/stripeController.js
@@ -50,7 +50,6 @@ const handleWebhook = async (req, res) => {
       stripe_event_id: event.id,
       event_type: event.type,
       organization_id: null,
-      license_id: null,
       event_data: event
     };
 

--- a/backend/src/db/queries/licenseQueries.js
+++ b/backend/src/db/queries/licenseQueries.js
@@ -140,12 +140,12 @@ const canAddCar = async (organizationId) => {
 
 // Create stripe event record
 const createStripeEvent = async (eventData) => {
-  const { id, stripe_event_id, event_type, organization_id, license_id, event_data } = eventData;
+  const { id, stripe_event_id, event_type, organization_id, event_data } = eventData;
   
   return query(
-    `INSERT INTO stripe_events (id, stripe_event_id, event_type, organization_id, license_id, event_data) 
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    [id, stripe_event_id, event_type, organization_id, license_id, JSON.stringify(event_data)]
+    `INSERT INTO stripe_events (id, stripe_event_id, event_type, organization_id, event_data) 
+     VALUES (?, ?, ?, ?, ?)`,
+    [id, stripe_event_id, event_type, organization_id, JSON.stringify(event_data)]
   );
 };
 
@@ -161,8 +161,8 @@ const isStripeEventProcessed = async (stripeEventId) => {
 // Update stripe event status
 const updateStripeEventStatus = async (stripeEventId, status, errorMessage = null) => {
   return query(
-    'UPDATE stripe_events SET processing_status = ?, error_message = ? WHERE stripe_event_id = ?',
-    [status, errorMessage, stripeEventId]
+    'UPDATE stripe_events SET processed = ?, processed_at = CURRENT_TIMESTAMP WHERE stripe_event_id = ?',
+    [status === 'processed' ? true : false, stripeEventId]
   );
 };
 


### PR DESCRIPTION
- Remove license_id column reference (doesn't exist in stripe_events table)
- Fix processing_status column name to match schema (processed)
- Update webhook controller to match database schema
- This resolves the 'Unknown column license_id' database error