### PR TITLE
Add version parameters to force cache invalidation for legal updates

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=1.1">
+    <link rel="stylesheet" href="styles.css?v=1.2">
     
     <!-- JSON-LD Schema Markup -->
     <script type="application/ld+json">
@@ -474,7 +474,7 @@
         </div>
     </footer>
 
-    <script src="script.js"></script>
+    <script src="script.js?v=1.2"></script>
     <!--Start of Tawk.to Script-->
     <script type="text/javascript">
     var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();


### PR DESCRIPTION
- Add v=1.2 to both styles.css and script.js
- Forces browsers and CDNs to reload files with legal agreement checkboxes
- Ensures users see updated signup modal with Terms/Privacy checkboxes